### PR TITLE
Change to make ldbc not run out of memory on huge responses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+dist
+.idea
+bin

--- a/src/eu/ldbc/semanticpublishing/TestDriver.java
+++ b/src/eu/ldbc/semanticpublishing/TestDriver.java
@@ -628,7 +628,7 @@ public class TestDriver {
 			interrupterThread.setDaemon(true);
 			interrupterThread.start();
 			
-			Thread reporterThread = new TestDriverReporter(Statistics.totalAggregateQueryStatistics.getRunsCountAtomicLong(),
+			Thread reporterThread = new TestDriverReporter(aggregationAgents, Statistics.totalAggregateQueryStatistics.getRunsCountAtomicLong(),
 														   Statistics.totalCompletedQueryMixRuns,
 													       inBenchmarkState, 
 													       keepReporterAlive,
@@ -751,7 +751,7 @@ public class TestDriver {
 			interrupterThread.setDaemon(true);
 			interrupterThread.start();
 			
-			Thread reporterThread = new TestDriverReporter(Statistics.totalAggregateQueryStatistics.getRunsCountAtomicLong(), 
+			Thread reporterThread = new TestDriverReporter(aggregationAgents, Statistics.totalAggregateQueryStatistics.getRunsCountAtomicLong(),
 														   Statistics.totalCompletedQueryMixRuns,
 													       inBenchmarkState,
 													       keepReporterAlive, 

--- a/src/eu/ldbc/semanticpublishing/TestDriverReporter.java
+++ b/src/eu/ldbc/semanticpublishing/TestDriverReporter.java
@@ -1,11 +1,13 @@
 package eu.ldbc.semanticpublishing;
 
+import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import eu.ldbc.semanticpublishing.agents.AbstractAsynchronousAgent;
 import eu.ldbc.semanticpublishing.statistics.Statistics;
 
 /**
@@ -21,6 +23,7 @@ public class TestDriverReporter extends Thread {
 	private final AtomicBoolean maxUpdateRateReached;
 	private final String queryPoolsDefinitions;
 	private final double maxUpdateRateThresholdOps;
+	private final List<AbstractAsynchronousAgent> aggregationAgents;
 	private double minUpdateRateThresholdOps;	
 	private double updateRateReachTimePercent;
 	private boolean verbose;
@@ -36,7 +39,12 @@ public class TestDriverReporter extends Thread {
 	
 	private final static Logger LOGGER = LoggerFactory.getLogger(TestDriverReporter.class.getName());
 	
-	public TestDriverReporter(AtomicLong totalQueryExecutions, AtomicLong totalCompletedQueryMixRuns, AtomicBoolean benchmarkState, AtomicBoolean keepAlive, AtomicBoolean benchmarkResultIsValid, double updateQueryRateFirstReachTimePercent, double minUpdateQueriesRateThresholdOps, double maxUpdateRateThresholdOps, AtomicBoolean maxUpdateRateReached, int editorialAgentsCount, int aggregationAgentsCount, long runPeriodSeconds, /*long benchmarkByQueryMixRuns, long benchmarkByQueryRuns, */String queryPoolsDefinitons, int reportPeriodSeconds , boolean verbose) {
+	public TestDriverReporter(List<AbstractAsynchronousAgent> aggregationAgents, AtomicLong totalQueryExecutions,
+			AtomicLong totalCompletedQueryMixRuns, AtomicBoolean benchmarkState, AtomicBoolean keepAlive, AtomicBoolean benchmarkResultIsValid, double updateQueryRateFirstReachTimePercent,
+			double minUpdateQueriesRateThresholdOps, double maxUpdateRateThresholdOps, AtomicBoolean maxUpdateRateReached, int editorialAgentsCount, int aggregationAgentsCount,
+			long runPeriodSeconds, /*long benchmarkByQueryMixRuns, long benchmarkByQueryRuns, */
+			String queryPoolsDefinitons, int reportPeriodSeconds, boolean verbose) {
+		this.aggregationAgents = aggregationAgents;
 		this.totalQueryExecutions = totalQueryExecutions;
 		this.totalCompletedQueryMixRuns = totalCompletedQueryMixRuns;
 		this.benchmarkState = benchmarkState;
@@ -145,7 +153,13 @@ public class TestDriverReporter extends Thread {
 
 		sb.append("\n");
 		sb.append("\tAggregation:\n");
-		sb.append(String.format("\t\t%s agents\n\n", aggregationAgentsCount));
+		int aliveCount = 0;
+		for (Thread agent : aggregationAgents) {
+			if (agent.isAlive()) {
+				aliveCount++;
+			}
+		}
+		sb.append(String.format("\t\t%s agents(%s)\"\n\n", aggregationAgentsCount, aliveCount));
 		if (verbose) {
 			for (int i = 0; i < Statistics.AGGREGATE_QUERIES_COUNT; i++) {
 				sb.append(String.format("\t\t%-5d Q%-2d  queries (avg : %-7d ms, min : %-7d ms, max : %-7d ms, %d errors)\n", Statistics.aggregateQueriesArray[i].getRunsCount(), 

--- a/src/eu/ldbc/semanticpublishing/agents/AbstractAsynchronousAgent.java
+++ b/src/eu/ldbc/semanticpublishing/agents/AbstractAsynchronousAgent.java
@@ -16,13 +16,19 @@ public abstract class AbstractAsynchronousAgent extends Thread {
 
 	@Override
 	public void run() {
-		while(runFlag.get()) {
-			if(! executeLoop() ) {
-				break;
-			}
-		}
-		executeFinalize();
-	}
+        try {
+            while(runFlag.get()) {
+                if(! executeLoop() ) {
+                    break;
+                }
+            }
+            executeFinalize();
+        // this thread died, make sure that this is logged properly everywhere.
+        } catch (Throwable e) {
+            e.printStackTrace(System.out);
+            throw new RuntimeException(e);
+        }
+    }
 	
 	/**
 	 * This method will be called repeatedly until either runFlag is set to false

--- a/src/eu/ldbc/semanticpublishing/agents/AggregationAgent.basic
+++ b/src/eu/ldbc/semanticpublishing/agents/AggregationAgent.basic
@@ -85,7 +85,7 @@ public class AggregationAgent extends AbstractAsynchronousAgent {
 		long queryId = 0;
 		MustacheTemplate aggregateQuery = null;
 		String queryString = "";
-		String queryResult = "";
+		InputStream queryResult = null;
 
 		try {
 //			boolean drillDownQuery = false;
@@ -149,7 +149,7 @@ public class AggregationAgent extends AbstractAsynchronousAgent {
 			
 			long executionTimeMs = System.currentTimeMillis();
 			
-			queryResult = queryExecuteManager.executeQuery(connection, aggregateQuery.getTemplateFileName(), queryString, aggregateQuery.getTemplateQueryType(), true, false);			
+			queryResult = queryExecuteManager.executeQueryStream(connection, aggregateQuery.getTemplateFileName(), queryString, aggregateQuery.getTemplateQueryType(), true, false);
 			
 			updateQueryStatistics(true, startedDuringBenchmarkPhase, aggregateQuery.getTemplateQueryType(), aggregateQuery.getTemplateFileName(), queryString, queryResult, queryId, System.currentTimeMillis() - executionTimeMs);
 
@@ -178,7 +178,7 @@ public class AggregationAgent extends AbstractAsynchronousAgent {
 		connection.disconnect();
 	}
 	
-	private void updateQueryStatistics(boolean reportSuccess, boolean startedDuringBenchmarkPhase, QueryType queryType, String queryName, String queryString, String queryResult, long id, long queryExecutionTimeMs) {
+	private void updateQueryStatistics(boolean reportSuccess, boolean startedDuringBenchmarkPhase, QueryType queryType, String queryName, String queryString, InputStream queryResult, long id, long queryExecutionTimeMs) {
 		//skip update of statistics for conformance queries
 		if (queryName.startsWith("#")) {
 			return;
@@ -189,21 +189,18 @@ public class AggregationAgent extends AbstractAsynchronousAgent {
 		
 		//count results (statements)
 		long resultsCount = 0;
-		InputStream iStream = null;
-				
-		try {			
-			if ((!queryResult.trim().isEmpty())) {			
-            iStream = new ByteArrayInputStream(queryResult.getBytes("UTF-8"));
+
+			if (hasAvailable(queryResult)) {
 		        if (queryType == QueryType.CONSTRUCT || queryType == QueryType.DESCRIBE) {
-		          resultsCount = turtleResultStatementsCounter.getStatementsCount(iStream);
+		          resultsCount = turtleResultStatementsCounter.getStatementsCount(queryResult);
 		          Statistics.timeCorrectionsMS.addAndGet(turtleResultStatementsCounter.getParseTime());
 		        } else {
-		          resultsCount = sparqlResultStatementsCounter.getStatementsCount(iStream);
+		          resultsCount = sparqlResultStatementsCounter.getStatementsCount(queryResult);
 		          Statistics.timeCorrectionsMS.addAndGet(sparqlResultStatementsCounter.getParseTime());
 		        }
 			}
 			
-			if (queryResult.length() >= 0 && benchmarkingState.get()) {
+			if (resultsCount >= 0 && benchmarkingState.get()) {
 				if (startedDuringBenchmarkPhase) {
 					if (reportSuccess) {
 						Statistics.aggregateQueriesArray[queryNumber - 1].reportSuccess(queryExecutionTimeMs);
@@ -216,22 +213,29 @@ public class AggregationAgent extends AbstractAsynchronousAgent {
 					}
 				} else {
 					if (queryExecutionTimeMs > 0) {
-						LOGGER.info("\tQuery : " + queryName + ", time : " + queryExecutionTimeMs + " ms, queryResult.length : " + queryResult.length() + ", results : " + resultsCount + ", has been started during the warmup phase, it will be ignored in the benchmark result!");
+						LOGGER.info("\tQuery : " + queryName + ", time : " + queryExecutionTimeMs + " ms, results : " + resultsCount + ", has been started during the warmup phase, it will be ignored in the benchmark result!");
 						logBrief(queryNameId, queryType, queryResult, ", has been started during the warmup phase, it will be ignored in the benchmark result!", queryExecutionTimeMs, resultsCount);
 					} else {
-						LOGGER.warn("\tQuery : " + queryName + ", time : " + queryExecutionTimeMs + " ms, queryResult.length : " + queryResult.length() + ", results : " + resultsCount + ", has failed to execute... possibly query timeout has been reached!");					
+						LOGGER.warn("\tQuery : " + queryName + ", time : " + queryExecutionTimeMs + " ms, results : " + resultsCount + ", has failed to execute... possibly query timeout has been reached!");
 						logBrief(queryNameId, queryType, queryResult, ", has failed to execute... possibly query timeout has been reached!", queryExecutionTimeMs, resultsCount);
 					}
 				}
 			}
 			
-			LOGGER.info("\n*** Query [" + queryNameId + "], execution time : " + queryExecutionTimeMs + " ms, results : " + resultsCount + "\n" + queryString + "\n---------------------------------------------\n*** Result for query [" + queryNameId + "]" + " : \n" + "Length : " + queryResult.length() + "\n" + queryResult + "\n\n");
-		} catch (UnsupportedEncodingException e) {
-			e.printStackTrace();
-		}
+			LOGGER.info("\n*** Query [" + queryNameId + "], execution time : " + queryExecutionTimeMs + " ms, results : " + resultsCount + "\n" + queryString + "\n---------------------------------------------\n\n***");
 	}
+
+	private boolean hasAvailable(InputStream queryResult) {
+    	try {
+    		return queryResult.available() > 0;
+    	} catch (IOException ex) {
+    		ex.printStackTrace();
+    	}
+    	return false;
+    }
+
 	
-	private void logBrief(String queryId, QueryType queryType, String queryResult, String appendString, long queryExecutionTimeMs, long resultStatementsCount) {
+	private void logBrief(String queryId, QueryType queryType, InputStream queryResult, String appendString, long queryExecutionTimeMs, long resultStatementsCount) {
 		StringBuilder reportSb = new StringBuilder();
 		reportSb.append(String.format("\t[%s, %s] Query executed, execution time : %d ms, results : %d %s", queryId, Thread.currentThread().getName(), queryExecutionTimeMs, resultStatementsCount, appendString));
 //		if (queryType == QueryType.SELECT || queryType == QueryType.CONSTRUCT || queryType == QueryType.DESCRIBE) {

--- a/src/eu/ldbc/semanticpublishing/endpoint/SparqlQueryExecuteManager.java
+++ b/src/eu/ldbc/semanticpublishing/endpoint/SparqlQueryExecuteManager.java
@@ -61,6 +61,23 @@ public class SparqlQueryExecuteManager {
 		return queryResult;		
 	}
 
+
+	public InputStream executeQueryStream(SparqlQueryConnection connection, String queryName, String queryString, QueryType queryType, boolean useInStatistics, boolean disconnect) throws IOException {
+
+		connection.setQueryString(queryString);
+		connection.setQueryType(queryType);
+		connection.prepareConnection(true);
+
+		InputStream is = connection.execute();
+
+		if (disconnect) {
+			connection.disconnect();
+		}
+
+		return is;
+	}
+
+
 	/**
 	 * A service method for executing queries not related to the benchmark run.
 	 * Always executed in a new connection, used for execution of queries during ontologies and reference datasets loading only.


### PR DESCRIPTION
This should fix a problem where threads were dying with out of memory
because of big responses from the driver. Although this shouldn't
happen(i.e. the queries should return expected results it was hard to
debug). Report the number of alive threads in the reporter now.