### PR TITLE
GDB-3723 Replaced “line.separator“ to be taken from System in StringU…

### DIFF
--- a/src/eu/ldbc/semanticpublishing/resultanalyzers/sax/SAXReferenceDataEntityTransformer.java
+++ b/src/eu/ldbc/semanticpublishing/resultanalyzers/sax/SAXReferenceDataEntityTransformer.java
@@ -160,9 +160,8 @@ public class SAXReferenceDataEntityTransformer extends DefaultHandler implements
 			entity.setCategory(categorySb.toString());
 			entity.setRank(rankSb.toString());
 			
-			if (!uniqueSet.contains(uriSb.toString())) {
+			if (uniqueSet.add(uriSb.toString())) {
 				entitiesList.add(entity);
-				uniqueSet.add(uriSb.toString());
 			}
 		}
 	}

--- a/src/eu/ldbc/semanticpublishing/util/RandomUtil.java
+++ b/src/eu/ldbc/semanticpublishing/util/RandomUtil.java
@@ -1,5 +1,6 @@
 package eu.ldbc.semanticpublishing.util;
 
+import org.apache.commons.lang3.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import java.io.BufferedReader;
@@ -422,7 +423,8 @@ public class RandomUtil {
 				escapeSb.append("\\");
 			}
 			escapeSb.append("\"");
-			replacement = sb.toString().replaceAll("\"", escapeSb.toString());			
+			replacement = sb.toString().replaceAll("\"", escapeSb.toString());
+			replacement = StringEscapeUtils.escapeJava(replacement).replace("\\", "\\");
 			sb.setLength(0);
 			sb.append(replacement);			
 		}

--- a/src/eu/ldbc/semanticpublishing/util/RandomUtil.java
+++ b/src/eu/ldbc/semanticpublishing/util/RandomUtil.java
@@ -401,6 +401,7 @@ public class RandomUtil {
 		StringBuilder sb = new StringBuilder();
 
 		if (!StringUtils.isEmpty(firstString)) {
+			// Some entities' object have ''' in them
 			sb.append(firstString.replace("'''", ""));
 			sb.append(" ");
 		}

--- a/src/eu/ldbc/semanticpublishing/util/RandomUtil.java
+++ b/src/eu/ldbc/semanticpublishing/util/RandomUtil.java
@@ -1,5 +1,7 @@
 package eu.ldbc.semanticpublishing.util;
 
+import org.apache.commons.lang3.StringUtils;
+
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
@@ -398,8 +400,10 @@ public class RandomUtil {
 			boolean appendDataType) {
 		StringBuilder sb = new StringBuilder();
 
-		sb.append(firstString);
-		sb.append(" ");
+		if (!StringUtils.isEmpty(firstString)) {
+			sb.append(firstString.replace("'''", ""));
+			sb.append(" ");
+		}
 
 		for (int i = 0; i < numberOfWords; i++) {
 			sb.append(randomWordFromDictionary(false, false));

--- a/src/eu/ldbc/semanticpublishing/util/RandomUtil.java
+++ b/src/eu/ldbc/semanticpublishing/util/RandomUtil.java
@@ -424,7 +424,6 @@ public class RandomUtil {
 			}
 			escapeSb.append("\"");
 			replacement = sb.toString().replaceAll("\"", escapeSb.toString());
-			replacement = StringEscapeUtils.escapeJava(replacement).replace("\\", "\\");
 			sb.setLength(0);
 			sb.append(replacement);			
 		}

--- a/src/eu/ldbc/semanticpublishing/util/RandomUtil.java
+++ b/src/eu/ldbc/semanticpublishing/util/RandomUtil.java
@@ -423,8 +423,10 @@ public class RandomUtil {
 		}
 		
 		if (surroundWithQuotes) {
-			sb.insert(0, '"');
-			sb.append("\"");
+			// In order to handle cases where we have new line in data we should add ''' instead of quotes
+			char[] quotesArr = {39, 39, 39};
+			sb.insert(0, quotesArr);
+			sb.append("'''");
 		}
 
 		if (appendDataType) {

--- a/src/eu/ldbc/semanticpublishing/util/StringUtil.java
+++ b/src/eu/ldbc/semanticpublishing/util/StringUtil.java
@@ -6,26 +6,35 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 
 /**
  * A utility class for performing various operations on strings. 
  */
 public class StringUtil {
-	
+
+	private static String lineSeparator = System.getProperty("line.separator");
 	/**
-	 * Prepares a string from an input strem, used when needed to log a detailed query result
+	 * Prepares a string from an input stream, used when needed to log a detailed query result
 	 * @param is
 	 * @return
 	 * @throws IOException
 	 */
 	public static String iostreamToString(InputStream is) throws IOException {
-		BufferedReader br = new BufferedReader(new InputStreamReader(is, "UTF-8"));
+		BufferedReader br = null;
 		StringBuilder sb = new StringBuilder();
 	    String str;
-	    while (null != (str = br.readLine())) {
-	        sb.append(str).append("\r\n"); 
-	    }
-	    br.close();	    
+	    try {
+			br = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8));
+			while (null != (str = br.readLine())) {
+				sb.append(str).append(lineSeparator);
+			}
+		} finally {
+	    	if (br != null) {
+				br.close();
+			}
+		}
+
 	    return sb.toString();
 	}	
 	

--- a/src/eu/ldbc/semanticpublishing/validation/EditorialOperationsValidator.java
+++ b/src/eu/ldbc/semanticpublishing/validation/EditorialOperationsValidator.java
@@ -210,9 +210,10 @@ public class EditorialOperationsValidator extends Validator {
 	
 	private String buildModifiedString(String inputString, int iteration) {
 		StringBuilder sb = new StringBuilder();
-		//insert first quote 
-		String firstPart = inputString.substring(0, 1);
-		String secondPart = inputString.substring(1);
+		// New implementation of method randomWordFromDictionary of RandomUtil class
+		// literals of type <http://www.w3.org/2001/XMLSchema#string> are in ''' instead of quotes.
+		String firstPart = inputString.substring(0, 3);
+		String secondPart = inputString.substring(3);
 		sb.append(firstPart);
 		sb.append("_updated_" + iteration);
 		sb.append(secondPart);

--- a/src/eu/ldbc/semanticpublishing/validation/Validator.java
+++ b/src/eu/ldbc/semanticpublishing/validation/Validator.java
@@ -143,14 +143,22 @@ public class Validator {
 			if (result.startsWith("<")) {
 				result = result.substring(1);
 			}
-			if (result.endsWith(">")) {
-				result = result.substring(0, result.length()-1);
-			}				
+			// Should be called before next because ^^<http://www.w3.org/2001/XMLSchema#string>
 			if (result.contains("^^")) {
 				result = result.substring(0, result.indexOf("^^"));
 			}
-			
-			result = result.replace("\"", "");
+			if (result.endsWith(">")) {
+				result = result.substring(0, result.length()-1);
+			}				
+
+			// Since we're adding ''' for literals with new line in them should remove them also
+			result = result.replace("'''", "");
+
+			// Remove only first and last quote
+			result = result.replaceFirst("\"", "");
+			if (result.endsWith("\"")) {
+				result = result.substring(0, result.lastIndexOf("\""));
+			}
 		}
 		
 		//escapeJava() returns UTF-8 escaped chars with double "\\"

--- a/src/eu/ldbc/semanticpublishing/validation/Validator.java
+++ b/src/eu/ldbc/semanticpublishing/validation/Validator.java
@@ -155,7 +155,9 @@ public class Validator {
 			result = result.replace("'''", "");
 
 			// Remove only first and last quote
-			result = result.replaceFirst("\"", "");
+			if (result.startsWith("\"")) {
+				result = result.replaceFirst("\"", "");
+			}
 			if (result.endsWith("\"")) {
 				result = result.substring(0, result.lastIndexOf("\""));
 			}


### PR DESCRIPTION
…tils class.

     Also changed Literals to be quoted with ''' instead with quote, which allows literals with new lines in them to not generate incorrect queries.
     Changed place of evaluation of if (result.contains("^^")) { to happen before if (result.endsWith(">")) { in transformString method of Validator class